### PR TITLE
Add Laravel 12 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,27 +9,27 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4]
-        laravel: [6.*]
+        php: [8.2, 8.3, 8.4]
+        laravel: [12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 6.*
-            testbench: 4.*
+          - laravel: 12.*
+            testbench: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extension-csv: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,16 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0"
+        "php": "^8.2",
+        "illuminate/support": "^12.0",
+        "illuminate/database": "^12.0",
+        "illuminate/contracts": "^12.0",
+        "nesbot/carbon": "^3.0"
     },
     "require-dev": {
-        "symfony/var-dumper": "^4.3 || ^5.1 || ^6.0",
-        "phpunit/phpunit": "^8.2 || ^9.3"
+        "orchestra/testbench": "^10.0",
+        "phpunit/phpunit": "^11.0",
+        "symfony/var-dumper": "^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/database/migrations/create_wallet_plus_tables.php.stub
+++ b/database/migrations/create_wallet_plus_tables.php.stub
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateWalletPlusTables extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.

--- a/database/migrations/create_wallet_plus_tables.php.stub
+++ b/database/migrations/create_wallet_plus_tables.php.stub
@@ -53,4 +53,4 @@ return new class extends Migration
         Schema::dropIfExists('wallets');
         Schema::dropIfExists('wallet_ledgers');
     }
-}
+};

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+     bootstrap="vendor/autoload.php"
+     colors="true"
+>
     <testsuites>
-        <testsuite name="CoreProc Test Suite">
+        <testsuite name="Package Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+        </include>
+    </source>
 </phpunit>

--- a/src/WalletPlusServiceProvider.php
+++ b/src/WalletPlusServiceProvider.php
@@ -11,7 +11,7 @@ class WalletPlusServiceProvider extends ServiceProvider
     /**
      * Bootstrap the application services.
      */
-    public function boot(Filesystem $filesystem)
+    public function boot(Filesystem $filesystem): void
     {
         $this->publishes([
             __DIR__ . '/../database/migrations/create_wallet_plus_tables.php.stub' =>
@@ -22,7 +22,7 @@ class WalletPlusServiceProvider extends ServiceProvider
     /**
      * Register the application services.
      */
-    public function register()
+    public function register(): void
     {
         // $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'wallet-plus');
     }


### PR DESCRIPTION
This pull request upgrades the package to support the latest versions of PHP, Laravel, and related dependencies. It also updates the CI workflow and configuration files to align with modern standards and best practices. The most important changes are grouped below:

**Dependency and Compatibility Upgrades:**

* Updated `composer.json` to require PHP 8.2+, Laravel 12.x components, and the latest versions of `orchestra/testbench`, `phpunit`, and `symfony/var-dumper`.
* Updated GitHub Actions workflow (`.github/workflows/run-tests.yml`) to test against PHP 8.2–8.4 and Laravel 12.x, and to use the latest action versions.

**Testing and Configuration Modernization:**

* Modernized `phpunit.xml.dist` to use the latest PHPUnit schema and configuration options, including updated test suite naming and source inclusion.

**Codebase Modernization:**

* Updated the migration stub (`database/migrations/create_wallet_plus_tables.php.stub`) to use an anonymous class, following Laravel 8+ conventions.
* Added return type hints (`void`) to the `boot` and `register` methods in `WalletPlusServiceProvider` for improved type safety. [[1]](diffhunk://#diff-9c9bdbc3be35fd7cf4bae2af8d53f1a97fffbdd36637fbe34ff069e62f9aa3baL14-R14) [[2]](diffhunk://#diff-9c9bdbc3be35fd7cf4bae2af8d53f1a97fffbdd36637fbe34ff069e62f9aa3baL25-R25)